### PR TITLE
Fix truncated value from post request.

### DIFF
--- a/src/MPFDParser/Field.cc
+++ b/src/MPFDParser/Field.cc
@@ -145,7 +145,7 @@ std::string MPFD::Field::GetTextTypeContent() {
 	    if (FieldContent.empty()) {
                 return std::string();
             } else {
-                return std::string(&FieldContent[0]);
+                return std::string( FieldContent.begin(), FieldContent.end() );
             }
         }
     }


### PR DESCRIPTION
For some unknown reason the value o `id` parameter was truncated when read by function `GetTextTypeContent`.

The returned value of `id` parameter was `00f189b3d867b11d7f4f7b67` instead of `00f189b3d867b11d7f4f7b6714881b92b1071ed6c01d1909b4bd97b97f3111c9`.
The other parameter are correct.

Below is the request dump from devtools.

```
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="id"

00f189b3d867b11d7f4f7b6714881b92b1071ed6c01d1909b4bd97b97f3111c9
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="tb"

Prospect
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="kind"

F
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="fullname"

FLAVIANA ALVARENGA DOS SANTOS
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="birthdate"

2014-09-30
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="sex"

N
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="cpf"

00000000000
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="cnpj"


------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="rg"

30736303-X
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="cellPhoneOperator"

NONE
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="cellPhone"

NULL
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="landline"

3941-2271
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="whatsapp"


------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="email"

teste@teste.com.br
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="postalCode"

12209-005
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="address"

RUA ROMEU CARNEVALE
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="addressNumber"

208
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="addressComplement"


------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="neighborhood"

JD BELA VISTA
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="city"

S�O JOS� DOS CAMPOS
------WebKitFormBoundaryswM9pgrvovtX627K
Content-Disposition: form-data; name="uf"

SP
------WebKitFormBoundaryswM9pgrvovtX627K--
```